### PR TITLE
認証基盤の実装

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import todos from "./routes/todos.js";
+import auth from  "./routes/auth.js";
 
 const app = new Hono();
 
@@ -10,13 +11,14 @@ app.use(
   "/api/*",
   cors({
     origin: ["http://localhost:5173"],
-    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],  
     allowHeaders: ["Content-Type"],
   })
 );
 
 // ルーターを登録
 app.route("/api/todos", todos);
+app.route("/api/auth", auth);
 
 // サーバーの起動
 const port = Number(process.env.PORT ?? 3000);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -15,10 +15,12 @@ auth.post("/signup", async (c) => {
   }
 
   try {
-    // usersテーブルにデータを挿入、月額設定額がゼロの場合、ゼロを設定する
+    // usersテーブルにデータを挿入、月額設定額が未設定の場合、０を設定する
+    const budget = monthly_budget ?? 0;
+
     const [result] = await pool.query<mysql.ResultSetHeader>(
       "INSERT INTO users (user_name, user_password, user_email, monthly_budget) VALUES (?, ?, ?, ?)",
-      [user_name, user_password, user_email, monthly_budget || 0]
+      [user_name, user_password, user_email, budget]
     );
 
     // ユーザー登録成功した場合
@@ -27,7 +29,8 @@ auth.post("/signup", async (c) => {
       user:{
         user_id: result.insertId,
         user_name: user_name,
-        monthly_budget: monthly_budget || 0
+        user_email: user_email,
+        monthly_budget: budget
       }
     }, 201);
   } catch (e) {
@@ -65,20 +68,15 @@ auth.post("/login", async (c) => {
       return c.json({ message: "メールアドレスとパスワードは必須です" }, 400);
     }
 
-    // 名前とパスワードが両方とも一致するデータがあるか検索
+    // メールアドレスとパスワードが一致するユーザー情報があるか検索
     const [rows] = await pool.query<mysql.RowDataPacket[]>(
       "SELECT * FROM users WHERE user_email = ? AND user_password = ?",
       [user_email, user_password]
     );
 
-    // ユーザー名パスワードを取得できなかった場合
+    // ユーザー情報を取得できなかった場合
     if (rows.length === 0) {
       return c.json({ message: "メールアドレスまたはパスワードが正しくありません" }, 401);
-    }
-
-    // 複数ある場合
-    if (rows.length > 1) {
-      return c.json({ message: "メールアドレスが重複しています" }, 500);
     }
 
     const user = rows[0];
@@ -124,7 +122,7 @@ auth.put("/update-budget", async (c) => {
 
   } catch(e){
     console.error(e);
-    return c.json({ message: "予算の更新に失敗しました"}, 500);
+    return c.json({ message: "予算の更新処理中に予期せぬエラーが発生しました" }, 500);
   }
 });
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,97 @@
+import { Hono } from "hono";
+import mysql from "mysql2/promise";
+import pool from "../db/index.js";
+
+const auth = new Hono(); 
+
+// POST /api/auth/signup　新規登録
+auth.post("/signup", async (c) => {
+  const body = await c.req.json();
+  const { user_name, user_password, monthly_budget } = body;
+
+  // 入力項目の必須チェック
+  if (!user_name || !user_password) {
+    return c.json({ message: "ユーザー名とパスワードは必須です"}, 400);
+  }
+  
+  try {
+    // usersテーブルにデータを挿入、月額設定額がゼロの場合、ゼロを設定する
+    const [result] = await pool.query<mysql.ResultSetHeader>(
+      "INSERT INTO users (user_name, user_password, monthly_budget) VALUES (?, ?, ?)",
+      [user_name, user_password, monthly_budget || 0]
+    );
+  
+    // ユーザー登録成功した場合  
+    return c.json({ 
+      message: "新規ユーザー登録が完了しました。",
+      user:{
+        user_id: result.insertId, 
+        user_name: user_name,
+        monthly_budget: monthly_budget || 0
+      } 
+    }, 201);
+  } catch (e) {
+    // 接続エラー等の場合  
+    console.error(e);
+    return c.json({ message: "登録に失敗しました。名前が既に使われています。" }, 500);
+  }
+});
+
+// POST /api/auth/login - ログイン
+auth.post("/login", async (c) => {
+  // 入力されたユーザー名とパスワードを取得する
+  const body = await c.req.json();
+  const { user_name, user_password } = body;
+
+  // 名前とパスワードが両方とも一致するデータがあるか検索
+  const [rows] = await pool.query<mysql.RowDataPacket[]>(
+    "SELECT * FROM users WHERE user_name = ? AND user_password = ?",
+    [user_name, user_password]
+  );
+
+  // 一致するデータが見つからない場合  
+  if (rows.length === 0) {
+    return c.json({ message: "ユーザー名またはパスワードが正しくありません" }, 401);
+  }
+
+  const user = rows[0];
+
+  // ログインに成功した場合
+  return c.json({ 
+    message: "ログインに成功しました", 
+    user: {
+      user_id: user.user_id,
+      user_name: user.user_name,
+      monthly_budget: user.monthly_budget 
+    } 
+  });
+});
+
+// api/auth/update-budget　-月額設定
+auth.patch("/update-budget", async (c) => {
+  try {
+    const body = await c.req.json();
+    const { user_id, monthly_budget } = body;
+
+    if (!user_id || monthly_budget === undefined){
+      return c.json({ message: "ユーザーIDと予算額が必要です"}, 400);
+    }
+    const [result] = await pool.query<mysql.ResultSetHeader>(
+      "UPDATE users SET monthly_budget = ? WHERE user_id = ?",
+      [monthly_budget, user_id]
+    );
+    if(result.affectedRows === 0){
+      return c.json({ message: "ユーザーが見つかりませんでした"}, 404);
+    }
+    return c.json({
+      message: "予算額を更新しました",
+      monthly_budget: monthly_budget
+    });
+    
+  } catch(e){
+    console.error(e);
+    return c.json({ message: "予算の更新に失敗しました"}, 500);
+  }
+});
+
+export default auth;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,73 +2,107 @@ import { Hono } from "hono";
 import mysql from "mysql2/promise";
 import pool from "../db/index.js";
 
-const auth = new Hono(); 
+const auth = new Hono();
 
 // POST /api/auth/signup　新規登録
 auth.post("/signup", async (c) => {
   const body = await c.req.json();
-  const { user_name, user_password, monthly_budget } = body;
+  const { user_name, user_password, user_email, monthly_budget } = body;
 
   // 入力項目の必須チェック
-  if (!user_name || !user_password) {
-    return c.json({ message: "ユーザー名とパスワードは必須です"}, 400);
+  if (!user_name || !user_password || !user_email) {
+    return c.json({ message: "ユーザー名、パスワード、メールアドレスは必須です"}, 400);
   }
-  
+
   try {
     // usersテーブルにデータを挿入、月額設定額がゼロの場合、ゼロを設定する
     const [result] = await pool.query<mysql.ResultSetHeader>(
-      "INSERT INTO users (user_name, user_password, monthly_budget) VALUES (?, ?, ?)",
-      [user_name, user_password, monthly_budget || 0]
+      "INSERT INTO users (user_name, user_password, user_email, monthly_budget) VALUES (?, ?, ?, ?)",
+      [user_name, user_password, user_email, monthly_budget || 0]
     );
-  
-    // ユーザー登録成功した場合  
-    return c.json({ 
+
+    // ユーザー登録成功した場合
+    return c.json({
       message: "新規ユーザー登録が完了しました。",
       user:{
-        user_id: result.insertId, 
+        user_id: result.insertId,
         user_name: user_name,
         monthly_budget: monthly_budget || 0
-      } 
+      }
     }, 201);
   } catch (e) {
-    // 接続エラー等の場合  
+    // 接続エラー等の場合
     console.error(e);
-    return c.json({ message: "登録に失敗しました。名前が既に使われています。" }, 500);
+
+    // エラーオブジェクトを型定義
+    const error = e as { code?: string };
+
+    // 重複の場合
+    if (error.code === "ER_DUP_ENTRY") {
+
+      return c.json({ message: "メールアドレスが既に使われています。" }, 409);
+    }
+
+    // DB接続エラーの場合
+    return c.json({ message: "登録に失敗しました。" }, 500);
   }
 });
 
 // POST /api/auth/login - ログイン
 auth.post("/login", async (c) => {
-  // 入力されたユーザー名とパスワードを取得する
-  const body = await c.req.json();
-  const { user_name, user_password } = body;
+  try {
+    // 入力されたユーザー名とパスワードを取得する
+    const body = await c.req.json();
+    const { user_email, user_password } = body;
 
-  // 名前とパスワードが両方とも一致するデータがあるか検索
-  const [rows] = await pool.query<mysql.RowDataPacket[]>(
-    "SELECT * FROM users WHERE user_name = ? AND user_password = ?",
-    [user_name, user_password]
-  );
+    // 型定義と必須チェック
+    if (
+      typeof user_email !== "string" ||
+      typeof user_password !== "string" ||
+      !user_email ||
+      !user_password
+    ) {
+      return c.json({ message: "メールアドレスとパスワードは必須です" }, 400);
+    }
 
-  // 一致するデータが見つからない場合  
-  if (rows.length === 0) {
-    return c.json({ message: "ユーザー名またはパスワードが正しくありません" }, 401);
+    // 名前とパスワードが両方とも一致するデータがあるか検索
+    const [rows] = await pool.query<mysql.RowDataPacket[]>(
+      "SELECT * FROM users WHERE user_email = ? AND user_password = ?",
+      [user_email, user_password]
+    );
+
+    // ユーザー名パスワードを取得できなかった場合
+    if (rows.length === 0) {
+      return c.json({ message: "メールアドレスまたはパスワードが正しくありません" }, 401);
+    }
+
+    // 複数ある場合
+    if (rows.length > 1) {
+      return c.json({ message: "メールアドレスが重複しています" }, 500);
+    }
+
+    const user = rows[0];
+
+    // ログインに成功した場合
+    return c.json({
+      message: "ログインに成功しました",
+      user: {
+        user_id: user.user_id,
+        user_name: user.user_name,
+        user_email: user.user_email,
+        monthly_budget: user.monthly_budget
+      }
+    });
+
+  } catch (e) {
+    // 例外処理
+    console.error(e);
+    return c.json({ message: "ログインに失敗しました" }, 500);
   }
-
-  const user = rows[0];
-
-  // ログインに成功した場合
-  return c.json({ 
-    message: "ログインに成功しました", 
-    user: {
-      user_id: user.user_id,
-      user_name: user.user_name,
-      monthly_budget: user.monthly_budget 
-    } 
-  });
 });
 
 // api/auth/update-budget　-月額設定
-auth.patch("/update-budget", async (c) => {
+auth.put("/update-budget", async (c) => {
   try {
     const body = await c.req.json();
     const { user_id, monthly_budget } = body;
@@ -87,7 +121,7 @@ auth.patch("/update-budget", async (c) => {
       message: "予算額を更新しました",
       monthly_budget: monthly_budget
     });
-    
+
   } catch(e){
     console.error(e);
     return c.json({ message: "予算の更新に失敗しました"}, 500);

--- a/backend/src/routes/details.ts
+++ b/backend/src/routes/details.ts
@@ -1,0 +1,109 @@
+import { Hono } from "hono";
+import mysql from "mysql2/promise";
+import pool from "../db/index.js";
+
+const details = new Hono();
+
+// POST /api/details - 支出の登録
+details.post("/", async (c) => {
+  try {
+    const body = await c.req.json();
+    const { user_id, expense_date, category_name, amount, description } = body;
+
+    if (!user_id || !expense_date || !category_name || !amount) {
+      return c.json({ message: "必須項目が不足しています" }, 400);
+    }
+
+    const connection = await pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+
+      // カテゴリIDの取得
+      const [categories] = await connection.query<mysql.RowDataPacket[]>(
+        "SELECT category_id FROM categories WHERE category_name = ? AND (user_id = ? OR user_id IS NULL) LIMIT 1",
+        [category_name, user_id]
+      );
+
+      let categoryId: number;
+      if (categories.length > 0) {
+        categoryId = categories[0].category_id;
+      } else {
+        const [result] = await connection.query<mysql.ResultSetHeader>(
+          "INSERT INTO categories (category_name, user_id) VALUES (?, ?)",
+          [category_name, user_id]
+        );
+        categoryId = result.insertId;
+      }
+
+      // details テーブルへの保存
+      await connection.query<mysql.ResultSetHeader>(
+        "INSERT INTO details (user_id, category_id, expense_date, amount, description) VALUES (?, ?, ?, ?, ?)",
+        [user_id, categoryId, expense_date, amount, description ?? ""]
+      );
+
+      await connection.commit();
+      return c.json({ message: "支出を登録しました" }, 201);
+
+    } catch (dbError) {
+      await connection.rollback();
+      throw dbError;
+    } finally {
+      connection.release();
+    }
+
+  } catch (e: any) {
+    console.error("[Details Registration Error]:", e);
+
+    if (e.code === "ECONNREFUSED" || e.code === "PROTOCOL_CONNECTION_LOST") {
+      return c.json({ message: "データベースに接続できません。" }, 503);
+    }
+    return c.json({ message: "登録に失敗しました。" }, 500);
+  }
+});
+
+// GET /api/details/dashboard/:user_id - ダッシュボード用データの取得
+details.get("/dashboard/:user_id", async (c) => {
+  try {
+    const userId = c.req.param("user_id");
+
+    const [userCheck] = await pool.query<mysql.RowDataPacket[]>(
+      "SELECT user_id FROM users WHERE user_id = ?",
+      [userId]
+    );
+
+    if (userCheck.length === 0) {
+      return c.json({ message: "ユーザーが見つかりません" }, 404);
+    }
+
+    const [totalRows] = await pool.query<mysql.RowDataPacket[]>(
+      `SELECT SUM(amount) as total FROM details
+       WHERE user_id = ? AND DATE_FORMAT(expense_date, '%Y-%m') = DATE_FORMAT(CURRENT_DATE, '%Y-%m')`,
+      [userId]
+    );
+    const monthlyTotal = totalRows[0].total || 0;
+
+    const [historyRows] = await pool.query<mysql.RowDataPacket[]>(
+      `SELECT d.expense_date, c.category_name, d.amount, d.description
+       FROM details d JOIN categories c ON d.category_id = c.category_id
+       WHERE d.user_id = ? ORDER BY d.expense_date DESC, d.detail_id DESC LIMIT 5`,
+      [userId]
+    );
+
+    return c.json({
+      message: "ダッシュボードデータの取得に成功しました",
+      monthlyTotal,
+      recentHistory: historyRows
+    }, 200);
+
+  } catch (e: any) {
+    console.error("[Dashboard Data Error]:", e);
+
+    if (e.code === "ECONNREFUSED" || e.code === "PROTOCOL_CONNECTION_LOST") {
+      return c.json({ message: "データベースに接続できません。" }, 503);
+    }
+    return c.json({ message: "データの取得に失敗しました。" }, 500);
+  }
+});
+
+export default details;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,12 @@ import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import Dashboard from "./pages/Dashboard";
 import ExpenseInput from "./pages/ExpenseInput";
-import ExpenseHistory from "./pages/ExpenseHistory";
-import ExpenseEdit from "./pages/ExpenseEdit";
 
 const App = () => {
-  // ログイン済みかの判定
+  // ログイン済みかどうかの判定
   const isAuthenticated = () => {
-    return localStorage.getItem("user") !== null;
+    // return localStorage.getItem("user") !== null;
+    return true;
   };
 
   return (
@@ -21,36 +20,24 @@ const App = () => {
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
 
-        {/* --- ログインしている場合、ダッシュボード画面、ログインしていない場合、ログイン画面 --- */}        
-        <Route 
-          path="/dashboard" 
-          element={isAuthenticated() ? <Dashboard /> : <Navigate to="/login" />} 
-        />
-        
-        {/* --- ログインしている場合、支出入力画面、ログインしていない場合、ログイン画面 --- */}        
-        <Route 
-          path="/input" 
-          element={isAuthenticated() ? <ExpenseInput /> : <Navigate to="/login" />} 
-        />
-        
-        {/* --- ログインしている場合、支出履歴画面、ログインしていない場合、ログイン画面 --- */}        
-        <Route 
-          path="/history" 
-          element={isAuthenticated() ? <ExpenseHistory /> : <Navigate to="/login" />} 
-        />
-        
-        {/* --- ログインしている場合、支出編集画面、ログインしていない場合、ログイン画面 --- */}        
-        <Route 
-          path="/edit/:id" 
-          element={isAuthenticated() ? <ExpenseEdit /> : <Navigate to="/login" />} 
+        {/* --- サイトのトップ、ログイン画面 --- */}
+        <Route
+          path="/"
+          element={ <Navigate to="/login" /> }
         />
 
-        {/* --- サイトのトップ、ログインしている場合、ダッシュボード画面、ログインしていない場合、ログイン画面 --- */}
-        <Route 
-          path="/" 
-          element={isAuthenticated() ? <Navigate to="/dashboard" /> : <Login />} 
+        {/* --- ログインしている場合、ダッシュボード画面、ログインしていない場合、ログイン画面 --- */}
+        <Route
+          path="/dashboard"
+          element={isAuthenticated() ? <Dashboard /> : <Navigate to="/login" />}
         />
-        
+
+        {/* --- ログインしている場合、支出入力画面、ログインしていない場合、ログイン画面 --- */}
+        <Route
+          path="/input"
+          element={isAuthenticated() ? <ExpenseInput /> : <Navigate to="/login" />}
+        />
+
         {/* 上記以外のURLの場合、サイトトップ（/）へ戻す */}
         <Route path="/*" element={<Navigate to="/" />} />
       </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,11 +5,6 @@ import Dashboard from "./pages/Dashboard";
 import ExpenseInput from "./pages/ExpenseInput";
 
 const App = () => {
-  // ログイン済みかどうかの判定
-  const isAuthenticated = () => {
-    // return localStorage.getItem("user") !== null;
-    return true;
-  };
 
   return (
     <BrowserRouter>
@@ -29,13 +24,13 @@ const App = () => {
         {/* --- ログインしている場合、ダッシュボード画面、ログインしていない場合、ログイン画面 --- */}
         <Route
           path="/dashboard"
-          element={isAuthenticated() ? <Dashboard /> : <Navigate to="/login" />}
+          element={<Dashboard /> }
         />
 
         {/* --- ログインしている場合、支出入力画面、ログインしていない場合、ログイン画面 --- */}
         <Route
           path="/input"
-          element={isAuthenticated() ? <ExpenseInput /> : <Navigate to="/login" />}
+          element={<ExpenseInput /> }
         />
 
         {/* 上記以外のURLの場合、サイトトップ（/）へ戻す */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,64 +1,60 @@
-import { useEffect, useState } from "react";
-import type { Todo } from "./types/todo";
-import { getTodos } from "./api/todos";
-import AddTodo from "./components/AddTodo";
-import TodoList from "./components/TodoList";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import Login from "./pages/Login";
+import Signup from "./pages/Signup";
+import Dashboard from "./pages/Dashboard";
+import ExpenseInput from "./pages/ExpenseInput";
+import ExpenseHistory from "./pages/ExpenseHistory";
+import ExpenseEdit from "./pages/ExpenseEdit";
 
 const App = () => {
-  const [todos, setTodos] = useState<Todo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // 初回マウント時に Todo 一覧を取得する
-  useEffect(() => {
-    const fetchTodos = async () => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const data = await getTodos();
-        setTodos(data);
-      } catch {
-        setError("Todo 一覧の取得に失敗しました。");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    void fetchTodos();
-  }, []);
-
-  // 新しく作成された Todo を一覧に追加する
-  const handleCreated = (todo: Todo) => {
-    setTodos((prev) => [...prev, todo]);
-  };
-
-  // 更新された Todo で一覧を更新する
-  const handleUpdated = (updated: Todo) => {
-    setTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+  // ログイン済みかの判定
+  const isAuthenticated = () => {
+    return localStorage.getItem("user") !== null;
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="max-w-xl mx-auto px-4 py-10">
-        <h1 className="text-3xl font-bold text-gray-800 mb-8 text-center">
-          Todo リスト
-        </h1>
+    <BrowserRouter>
+      {/* --- どのURLでどの画面を表示させているか --- */}
 
-        {/* 新規 Todo 作成フォーム */}
-        <div className="mb-6">
-          <AddTodo onCreated={handleCreated} />
-        </div>
+      <Routes>
+        {/* --- ログイン画面・新規登録画面 --- */}
+        <Route path="/login" element={<Login />} />
+        <Route path="/signup" element={<Signup />} />
 
-        {/* Todo 一覧 */}
-        {isLoading ? (
-          <p className="text-center text-gray-400">読み込み中...</p>
-        ) : error ? (
-          <p className="text-center text-red-500">{error}</p>
-        ) : (
-          <TodoList todos={todos} onUpdated={handleUpdated} />
-        )}
-      </div>
-    </div>
+        {/* --- ログインしている場合、ダッシュボード画面、ログインしていない場合、ログイン画面 --- */}        
+        <Route 
+          path="/dashboard" 
+          element={isAuthenticated() ? <Dashboard /> : <Navigate to="/login" />} 
+        />
+        
+        {/* --- ログインしている場合、支出入力画面、ログインしていない場合、ログイン画面 --- */}        
+        <Route 
+          path="/input" 
+          element={isAuthenticated() ? <ExpenseInput /> : <Navigate to="/login" />} 
+        />
+        
+        {/* --- ログインしている場合、支出履歴画面、ログインしていない場合、ログイン画面 --- */}        
+        <Route 
+          path="/history" 
+          element={isAuthenticated() ? <ExpenseHistory /> : <Navigate to="/login" />} 
+        />
+        
+        {/* --- ログインしている場合、支出編集画面、ログインしていない場合、ログイン画面 --- */}        
+        <Route 
+          path="/edit/:id" 
+          element={isAuthenticated() ? <ExpenseEdit /> : <Navigate to="/login" />} 
+        />
+
+        {/* --- サイトのトップ、ログインしている場合、ダッシュボード画面、ログインしていない場合、ログイン画面 --- */}
+        <Route 
+          path="/" 
+          element={isAuthenticated() ? <Navigate to="/dashboard" /> : <Login />} 
+        />
+        
+        {/* 上記以外のURLの場合、サイトトップ（/）へ戻す */}
+        <Route path="/*" element={<Navigate to="/" />} />
+      </Routes>
+    </BrowserRouter>
   );
 };
 

--- a/frontend/src/Common/FormButton.tsx
+++ b/frontend/src/Common/FormButton.tsx
@@ -1,0 +1,17 @@
+// 再作成用のコード例
+type Props = {
+  type?: "button" | "submit" | "reset";
+  label: string;
+  className?: string;
+  onClick?: () => void;
+};
+
+const FormButton = ({ type = "button", label, className, onClick }: Props) => {
+  return (
+    <button type={type} className={className} onClick={onClick}>
+      {label}
+    </button>
+  );
+};
+
+export default FormButton;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,47 @@
+import type { User } from "../types/auth";
+
+// const BASE_URL = "/api/auth";
+const BASE_URL = "http://localhost:3000/api/auth";
+
+// ログイン時
+export const login = async (user_name: string, user_password: string): Promise<{ message: string; user?: User }> => {
+  const res = await fetch(`${BASE_URL}/login`,{
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_name, user_password }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to login: ${res.status}`);
+  }
+  return res.json() as Promise<{ message: string; user?: User }>;
+};
+
+// 新規登録時
+export const signup = async (user_name: string, user_password: string, monthly_budget: number)
+  : Promise<{ message: string; user?: User }> => {
+  const res = await fetch(`${BASE_URL}/signup`,{
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_name, user_password, monthly_budget }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to sign-up: ${res.status}`);
+  }
+  return res.json() as Promise<{ message: string; user?: User }>;
+};
+
+// 月額設定額登録
+export const updateBudget = async (user_id: number, monthly_budget: number)
+  : Promise<{ message: string; monthly_budget: number}> => {
+  const res = await fetch(`${BASE_URL}/update-budget`,{
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id, monthly_budget }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to update budget: ${res.status}`);
+  }
+
+  return res.json() as Promise<{ message: string; monthly_budget: number }>;
+};

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,47 +1,75 @@
 import type { User } from "../types/auth";
 
 // const BASE_URL = "/api/auth";
-const BASE_URL = "http://localhost:3000/api/auth";
+const BASE_URL = "/api/auth";
 
 // ログイン時
-export const login = async (user_name: string, user_password: string): Promise<{ message: string; user?: User }> => {
+export const login = async (
+  useremail: string,
+  userpassword: string
+  ) : Promise<{ message: string; user?: User }> => {
+  // ログインデータを送信
   const res = await fetch(`${BASE_URL}/login`,{
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ user_name, user_password }),
+    body: JSON.stringify({
+      user_email: useremail,
+      user_password: userpassword }),
   });
+
+  // レスポンスチェック
   if (!res.ok) {
     throw new Error(`Failed to login: ${res.status}`);
   }
+
+  // JSONデータとして返却
   return res.json() as Promise<{ message: string; user?: User }>;
 };
 
 // 新規登録時
-export const signup = async (user_name: string, user_password: string, monthly_budget: number)
-  : Promise<{ message: string; user?: User }> => {
+export const signup = async (
+  userName: string,
+  userPassword: string,
+  userEmail: string,
+  budget: number | null
+  ) : Promise<{ message: string; user?: User }> => {
+  // 新規登録データを送信
   const res = await fetch(`${BASE_URL}/signup`,{
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ user_name, user_password, monthly_budget }),
+    body: JSON.stringify({
+      user_name: userName,
+      user_password: userPassword,
+      user_email: userEmail,
+      monthly_budget: budget }),
   });
+
+  // レスポンスチェック
   if (!res.ok) {
     throw new Error(`Failed to sign-up: ${res.status}`);
   }
+
+  // JSONデータとして返却
   return res.json() as Promise<{ message: string; user?: User }>;
 };
 
 // 月額設定額登録
-export const updateBudget = async (user_id: number, monthly_budget: number)
-  : Promise<{ message: string; monthly_budget: number}> => {
+export const updateBudget = async (
+  user_id: number,
+  monthly_budget: number
+  ) : Promise<{ message: string; monthly_budget: number}> => {
+  // 予算データを更新
   const res = await fetch(`${BASE_URL}/update-budget`,{
-    method: "PATCH",
+    method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ user_id, monthly_budget }),
   });
 
+  // レスポンスチェック
   if (!res.ok) {
     throw new Error(`Failed to update budget: ${res.status}`);
   }
 
+  // JSONデータとして返却
   return res.json() as Promise<{ message: string; monthly_budget: number }>;
 };

--- a/frontend/src/api/details.ts
+++ b/frontend/src/api/details.ts
@@ -1,0 +1,53 @@
+import type { Detail } from "../types/expense";
+
+// 支出明細登録に必要なデータの型定義
+export type CreateDetailRequest = Omit<Detail, "detail_id" | "category_id"> & {
+  category_name: string;
+};
+
+// ダッシュボード取得用の型定義
+export interface DashboardDataResponse {
+  message: string;
+  monthlyTotal: number;
+  recentHistory: {
+    expense_date: string;
+    category_name: string;
+    amount: number;
+    description: string;
+  }[];
+};
+
+const BASE_URL = "/api/details";
+
+// 支出明細の新規登録
+export const createDetail = async (data: CreateDetailRequest): Promise<{ message: string }> => {
+  const res = await fetch(`${BASE_URL}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to create detail: ${res.status}`);
+  }
+
+  return res.json() as Promise<{ message: string }>;
+};
+
+// ダッシュボードデータの取得
+
+export const getDashboardData = async (user_id: number): Promise<DashboardDataResponse> => {
+  const res = await fetch(`${BASE_URL}/dashboard/${user_id}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch dashboard data: ${res.status}`);
+  }
+
+  return res.json() as Promise<DashboardDataResponse>;
+};

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getDashboardData, DashboardDataResponse } from "../api/details";
+import { User } from "../types/auth";
+import FormButton from "../Common/FormButton";
+
+const Dashboard = () => {
+  const navigate = useNavigate();
+
+  const [data, setData] = useState<DashboardDataResponse | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [apiError, setApiError] = useState("");
+
+  // 画面起動時にデータを取得
+  useEffect(() => {
+    const storedUser = localStorage.getItem("user");
+    if (storedUser) {
+      const parsedUser = JSON.parse(storedUser) as User;
+      setUser(parsedUser);
+      fetchData(parsedUser.user_id);
+    } else {
+      navigate("/login");
+    }
+  }, [navigate]);
+
+  const fetchData = async (userId: number) => {
+    try {
+      const response = await getDashboardData(userId);
+      setData(response);
+    } catch (error) {
+      setApiError("データの取得に失敗しました。");
+    }
+  };
+
+  // ログアウト処理
+  const handleLogout = () => {
+    localStorage.removeItem("user");
+    navigate("/login");
+  };
+
+  // 計算ロジック
+  const budget = user?.monthly_budget ?? 0;
+  const expense = data?.monthlyTotal ?? 0;
+  const balance = budget - expense;
+
+  // スタイル定義
+  const btnClass = "bg-blue-500 text-white py-2 px-4 rounded-md font-bold text-sm hover:bg-blue-600 transition-all shadow";
+  const editBtnClass = "ml-4 bg-blue-500 text-white py-1 px-3 rounded text-xs font-bold hover:bg-blue-600 transition-all shadow-sm";
+  const rowLabel = "w-32 text-gray-700 font-bold";
+  const rowValue = "w-32 text-right font-mono";
+
+  return (
+    <div className="p-10 max-w-4xl mx-auto">
+      {/* ヘッダー */}
+      <div className="flex justify-between items-center mb-10">
+        <h1 className="text-3xl font-bold text-gray-800">ダッシュボード</h1>
+        <div className="text-right">
+          <p className="text-sm mb-2">名前：{user?.user_name} 様</p>
+          <FormButton
+            label="ログアウト"
+            className={editBtnClass}
+            onClick={handleLogout}
+          />
+        </div>
+      </div>
+
+      {apiError && <p className="text-red-500 mb-4">{apiError}</p>}
+
+      {/* 予算・支出・残高表示エリア */}
+      <div className="space-y-4 mb-12 border-b pb-8">
+        <div className="flex items-center">
+          <span className={rowLabel}>今月の予算</span>
+          <span className={`${rowValue} text-red-500`}>{budget.toLocaleString()}円</span>
+          <FormButton
+            label="編集"
+            className={editBtnClass}
+            onClick={() => navigate("/update-budget")}
+          />
+        </div>
+        <div className="flex items-center">
+          <span className={rowLabel}>今月の支出</span>
+          <span className={rowValue}>{expense.toLocaleString()}円</span>
+        </div>
+        <div className="flex items-center">
+          <span className={rowLabel}>残高</span>
+          <span className={`${rowValue} ${balance < 0 ? 'text-red-500' : 'text-gray-800'}`}>
+            {balance.toLocaleString()}円
+          </span>
+        </div>
+      </div>
+
+      {/* 最近5件の履歴エリア */}
+      <div className="mb-10">
+        <h2 className="text-lg font-bold mb-4 text-gray-700">最近5件の履歴</h2>
+        <div className="border border-gray-400 p-4 rounded-md min-h-[150px] bg-white">
+          {data?.recentHistory && data.recentHistory.length > 0 ? (
+            <ul className="space-y-2">
+              {data.recentHistory.map((item, index) => (
+                <li key={index} className="flex justify-between text-sm border-b pb-1 border-gray-100">
+                  <span className="w-24 text-gray-500">{item.expense_date}</span>
+                  <span className="w-24 font-bold">{item.category_name}</span>
+                  <span className="flex-1 px-4 text-gray-600 truncate">{item.description}</span>
+                  <span className="w-24 text-right font-mono">{item.amount.toLocaleString()}円</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-center text-gray-400 mt-10">明細がありません。</p>
+          )}
+        </div>
+      </div>
+
+      {/* ナビゲーションボタン */}
+      <div className="flex justify-center space-x-6 mt-10">
+        <FormButton
+          label="支出を入力"
+          className={btnClass}
+          onClick={() => navigate("/input")}
+        />
+        <FormButton
+          label="履歴表示"
+          className={btnClass}
+          onClick={() => navigate("/history")}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/ExpenseInput.tsx
+++ b/frontend/src/pages/ExpenseInput.tsx
@@ -1,0 +1,160 @@
+import { useForm } from 'react-hook-form';
+import FormButton from '../Common/FormButton';
+import { useNavigate } from 'react-router-dom';
+import { createDetail, CreateDetailRequest } from '../api/details';
+
+// 型定義
+type InputFormValues = {
+  expense_date: string;
+  category_name: string;
+  amount: number;
+  description: string;
+}
+
+const ExpenseInput = () => {
+  const navigate = useNavigate();
+  const today = new Date().toISOString().split("T")[0];
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<InputFormValues>({
+    defaultValues: { expense_date: "", category_name: "",
+      amount: 0, description: "" }
+  });
+
+  // スタイル定義
+  const labelClass = "w-32 text-gray-700";
+  const btnClass = "bg-blue-500 text-black py-2 px-6 rounded-md font-bold text-sm hover:bg-blue-600 transition-all shadow";
+  const inputBase = "border-2 py-1 px-3 rounded-md focus:ring-2 focus:ring-blue-500 outline-none w-72 text-sm text-right";
+
+  const goToDashboard = () => navigate("/dashboard");
+
+  const onSubmit = async (data: InputFormValues) => {
+    try {
+      // ログイン情報
+      const userJson = localStorage.getItem("user");
+      const user = userJson ? JSON.parse(userJson) : null;
+
+      if (!user || !user.user_id){
+        alert("ログイン情報が見つかりません。再ログインしてください。");
+        navigate("/login");
+        return;
+      }
+
+      // 型定義
+      const requestData: CreateDetailRequest = {
+        user_id: Number(user.user_id),
+        expense_date: data.expense_date,
+        category_name: data.category_name,
+        amount: Number(data.amount),
+        description: data.description || ""
+      };
+
+      console.log("バックエンドデータ:", requestData);
+
+      await createDetail(requestData);
+      // 成功
+      alert ("登録完了");
+      navigate("/dashboard");
+
+    } catch (error){
+      console.error("登録エラー:", error);
+      alert("登録に失敗");
+    }
+  };
+
+  return (
+
+    <div className='pl-10 pt-10 max-w-2xl'>
+      <h1 className='text-3xl font-bold text-gray-800 mb-8'>支出入力</h1>
+
+      <form onSubmit={handleSubmit(onSubmit)} className='space-y-6' noValidate>
+
+        {/* 日付入力欄 */}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>日付</label>
+            <input
+              className={inputBase}
+              type="date"
+              max={today}
+              {...register("expense_date",{
+                required: "日付を入力してください",
+
+              })}
+            />
+          </div>
+          {/* エラーメッセージ表示の定義 */}
+          <div className='h-4 ml-32'>
+            {errors.expense_date && <span className='text-red-500 text-xs'>{errors.expense_date.message}</span>}
+          </div>
+        </div>
+
+        {/* カテゴリ入力欄 */}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>カテゴリ</label>
+            <input
+              className={`${inputBase} text-left`}
+              type="text"
+              {...register("category_name",{
+                required: "カテゴリを入力してください"
+              })}
+            />
+          </div>
+          {/* エラーメッセージ表示の定義 */}
+          <div className='h-4 ml-32'>
+            {errors.category_name && <span className='text-red-500 text-xs'>{errors.category_name.message}</span>}
+          </div>
+        </div>
+
+        {/* 金額入力欄 */}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>金額</label>
+            <input
+              className={inputBase}
+              type="number"
+              min="0"
+              {...register("amount",{
+                required: "金額を入力してください",
+                min: { value: 1, message: "１円以上の金額を入力して下さい" },
+              })}
+            />
+            <span className='ml-2 text-sm'>円</span>
+          </div>
+          {/* エラーメッセージ表示の定義 */}
+          <div className='h-4 ml-32'>
+            {errors.amount && <span className='text-red-500 text-xs'>{errors.amount.message}</span>}
+          </div>
+        </div>
+
+        {/* 費用詳細欄 */}
+        <div className='flex flex-col'>
+          <div className='flex items-start'>
+            <label className={`${labelClass} pt-1`}>費用詳細</label>
+            <textarea
+              className={`${inputBase} text-left p-2 h-auto`}
+              rows={2}
+              {...register("description",{
+              maxLength: { value: 20, message: "20文字以内で入力してください"},
+              })}
+            />
+          </div>
+          {/* エラーメッセージ表示の定義 */}
+          <div className='h-4 ml-32'>
+            {errors.description && <span className='text-red-500 text-xs'>{errors.description.message}</span>}
+          </div>
+        </div>
+
+        <div className='ml-32 w-72 flex justify-center space-x-4 mt-8'>
+          <FormButton type="button" label="キャンセル" className={btnClass} onClick={goToDashboard} />
+          <FormButton type="submit" label="確定" className={btnClass} />
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default ExpenseInput

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import FormButton from '../Common/FormButton';
+import { login } from '../api/auth';
+
+// 型定義
+type LoginFormValues = {
+  userName: string;
+  userPassword: string;
+};
+
+const Login = () => {
+  const navigate = useNavigate();
+  const [apiError, setApiError] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormValues>({
+    defaultValues: { userName: "", userPassword: "" }
+  });
+
+  const onSubmit = async (data: LoginFormValues) => {
+    setApiError("");
+    try {
+      const response = await login(data.userName, data.userPassword);
+      if (response.user) {
+        localStorage.setItem("user", JSON.stringify(response.user));
+        navigate("/dashboard");
+      }
+    } catch (error) {
+      setApiError("ユーザーIDまたはパスワードが違います");
+    }
+  };
+
+  const goToSignup = () => navigate("/signup");
+
+  // スタイル定義
+  const labelClass = "w-24 text-gray-700";
+  const btnClass = "bg-blue-500 text-black py-2 px-6 rounded-md font-bold text-sm hover:bg-blue-600 transition-all shadow";
+  const inputBase = "border-2 py-1 px-3 rounded-md focus:ring-2 focus:ring-blue-500 outline-none w-72 text-sm text-right";
+
+  return (
+    <div className='pl-10 pt-10 max-w-2xl'>
+      <h1 className='text-3xl font-bold text-gray-800 mb-8'>ログイン</h1>
+
+      {apiError && <p className="text-red-500 text-sm mb-4">{apiError}</p>}
+
+      <form onSubmit={handleSubmit(onSubmit)} className='space-y-6'>
+        
+        {/* ユーザーID入力欄 */}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>ユーザID</label>
+            <input 
+              className={`${inputBase} ${errors.userName ? 'border-red-500' : 'border-gray-400'}`}
+              {...register("userName", {
+                required: "ユーザIDを入力してください",
+                minLength: { value: 8, message: "8文字以上で入力してください" },
+                maxLength: { value: 19, message: "20文字未満で入力してください" },
+                pattern: {
+                  value: /^[a-zA-Z0-9]+$/,
+                  message: "英数字のみで入力してください"                
+                }
+              })} 
+            />
+          </div>
+          <div className='h-4 ml-24'>
+            {/* 入力項目の下に赤エラーメッセージを表示 */}
+            {errors.userName && (
+              <span className='text-red-500 text-xs'>{errors.userName.message}</span>)}
+          </div>
+        </div>
+        
+        {/* パスワード入力欄 */}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>パスワード</label>
+            <input 
+              type="password"
+              className={`${inputBase} ${errors.userPassword ? 'border-red-500' : 'border-gray-400'}`}
+              {...register("userPassword", { 
+                required: "パスワードを入力してください",
+                minLength: { value: 8, message: "8文字以上で入力してください" },
+                maxLength: { value: 19, message: "20文字未満で入力してください" },
+                // 英字・数字・記号の混在をチェック
+                pattern: {
+                value: /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[^\w\s]).+$/,
+                message: "英字・数字・記号をすべて含めてください"              
+                }
+              })} 
+            />
+          </div>
+          {/* エラーメッセージ表示の定義 */}
+          <div className='h-4 ml-24'>
+            {errors.userPassword && <span className='text-red-500 text-xs'>{errors.userPassword.message}</span>}
+          </div>
+        </div>
+
+        <div className='ml-24 w-72 flex justify-center space-x-4 mt-8'>
+          <FormButton type="regist" label="新規作成" className={btnClass} onClick={goToSignup} />
+          <FormButton type="submit" label="ログイン" className={btnClass} />
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -6,8 +6,8 @@ import { login } from '../api/auth';
 
 // 型定義
 type LoginFormValues = {
-  userName: string;
   userPassword: string;
+  userEmail: string;
 };
 
 const Login = () => {
@@ -19,26 +19,26 @@ const Login = () => {
     handleSubmit,
     formState: { errors },
   } = useForm<LoginFormValues>({
-    defaultValues: { userName: "", userPassword: "" }
+    defaultValues: { userPassword: "", userEmail:"" }
   });
 
   const onSubmit = async (data: LoginFormValues) => {
     setApiError("");
     try {
-      const response = await login(data.userName, data.userPassword);
+      const response = await login(data.userEmail, data.userPassword);
       if (response.user) {
         localStorage.setItem("user", JSON.stringify(response.user));
         navigate("/dashboard");
       }
     } catch (error) {
-      setApiError("ユーザーIDまたはパスワードが違います");
+      setApiError("メールアドレスまたはパスワードが違います");
     }
   };
 
   const goToSignup = () => navigate("/signup");
 
   // スタイル定義
-  const labelClass = "w-24 text-gray-700";
+  const labelClass = "w-32 text-gray-700 pt-1";
   const btnClass = "bg-blue-500 text-black py-2 px-6 rounded-md font-bold text-sm hover:bg-blue-600 transition-all shadow";
   const inputBase = "border-2 py-1 px-3 rounded-md focus:ring-2 focus:ring-blue-500 outline-none w-72 text-sm text-right";
 
@@ -48,59 +48,58 @@ const Login = () => {
 
       {apiError && <p className="text-red-500 text-sm mb-4">{apiError}</p>}
 
-      <form onSubmit={handleSubmit(onSubmit)} className='space-y-6'>
-        
-        {/* ユーザーID入力欄 */}
-        <div className='flex flex-col'>
-          <div className='flex items-center'>
-            <label className={labelClass}>ユーザID</label>
-            <input 
-              className={`${inputBase} ${errors.userName ? 'border-red-500' : 'border-gray-400'}`}
-              {...register("userName", {
-                required: "ユーザIDを入力してください",
-                minLength: { value: 8, message: "8文字以上で入力してください" },
-                maxLength: { value: 19, message: "20文字未満で入力してください" },
-                pattern: {
-                  value: /^[a-zA-Z0-9]+$/,
-                  message: "英数字のみで入力してください"                
-                }
-              })} 
-            />
-          </div>
-          <div className='h-4 ml-24'>
-            {/* 入力項目の下に赤エラーメッセージを表示 */}
-            {errors.userName && (
-              <span className='text-red-500 text-xs'>{errors.userName.message}</span>)}
-          </div>
-        </div>
-        
+      <form onSubmit={handleSubmit(onSubmit)} className='space-y-6' noValidate>
+
         {/* パスワード入力欄 */}
         <div className='flex flex-col'>
-          <div className='flex items-center'>
+          <div className='flex items-start'>
             <label className={labelClass}>パスワード</label>
-            <input 
+            <input
               type="password"
               className={`${inputBase} ${errors.userPassword ? 'border-red-500' : 'border-gray-400'}`}
-              {...register("userPassword", { 
-                required: "パスワードを入力してください",
+              {...register("userPassword", {
+                required: "パスワードは必須です",
                 minLength: { value: 8, message: "8文字以上で入力してください" },
                 maxLength: { value: 19, message: "20文字未満で入力してください" },
                 // 英字・数字・記号の混在をチェック
                 pattern: {
                 value: /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[^\w\s]).+$/,
-                message: "英字・数字・記号をすべて含めてください"              
+                message: "英字・数字・記号をすべて含めてください"
                 }
-              })} 
+              })}
             />
           </div>
           {/* エラーメッセージ表示の定義 */}
-          <div className='h-4 ml-24'>
+          <div className='h-4 ml-32'>
             {errors.userPassword && <span className='text-red-500 text-xs'>{errors.userPassword.message}</span>}
           </div>
         </div>
 
-        <div className='ml-24 w-72 flex justify-center space-x-4 mt-8'>
-          <FormButton type="regist" label="新規作成" className={btnClass} onClick={goToSignup} />
+        {/* メールアドレス入力欄 */}
+        <div className='flex flex-col'>
+          <div className='flex items-start'>
+            <label className={labelClass}>メールアドレス</label>
+            <input
+              type="email"
+              className={`${inputBase} ${errors.userEmail ? 'border-red-500' : 'border-gray-400'}`}
+              {...register("userEmail", {
+                required: "メールアドレスは必須です",
+                pattern: {
+                  value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                  message: "メールアドレスの形式が正しくありません"
+                }
+              })}
+            />
+          </div>
+          <div className='h-4 ml-32'>
+            {errors.userEmail && (
+              <span className='text-red-500 text-xs'>{errors.userEmail.message}</span>
+            )}
+          </div>
+        </div>
+
+        <div className='ml-32 w-72 flex justify-center space-x-4 mt-8'>
+          <FormButton type="button" label="新規作成" className={btnClass} onClick={goToSignup} />
           <FormButton type="submit" label="ログイン" className={btnClass} />
         </div>
       </form>

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import FormButton from "../Common/FormButton";
+import { signup } from "../api/auth";
+
+// 型定義
+type SignupFormValues = {
+  userName: string;
+  userPassword: string;
+  userEmail: string;
+  budget: number;
+};
+
+const Signup = () => {
+  const navigate = useNavigate();
+  const [apiError, setApiError] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignupFormValues>({
+    defaultValues: { userName: "", userPassword: "", userEmail:"", budget: 0 }
+  });
+
+  const handleGoToLogin = () => navigate("/login");
+
+  const onSubmit = async (data: SignupFormValues) => {
+    setApiError("");
+    try {
+      const response = await signup(data.userName, data.userPassword, data.userEmail, data.budget);
+      if (response.user) {
+        alert("登録が完了しました！ログインしてください。");
+        navigate("/login");
+      }
+    } catch (error) {
+      setApiError("登録に失敗しました。");
+    }
+  };
+
+  // スタイル定義
+  const labelClass = "w-32 text-gray-700";
+  const inputBase = "border-2 py-1 px-3 rounded-md focus:ring-2 focus:ring-blue-500 outline-none w-72 text-sm text-right";
+  const btnClass = "bg-blue-500 text-black py-2 px-6 rounded-md font-bold text-sm hover:bg-blue-600 transition-all shadow";
+
+  return (
+    <div className='pl-10 pt-10 max-w-2xl'>
+      <h1 className='text-3xl font-bold text-gray-800 mb-8'>新規登録</h1>
+
+      {apiError && <p className="text-red-500 text-sm mb-4">{apiError}</p>}
+
+      <form onSubmit={handleSubmit(onSubmit)} className='space-y-6' noValidate>
+
+        {/* ユーザー名入力欄　*/}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>ユーザー名</label>
+            <input
+              className={`${inputBase} ${errors.userName ? 'border-red-500' : 'border-gray-400'}`}
+              {...register("userName", {
+                required: "ユーザー名は必須です",
+              })}
+            />
+          </div>
+          <div className='h-4 ml-32'>
+            {errors.userName && <span className='text-red-500 text-xs'>{errors.userName.message}</span>}
+          </div>
+        </div>
+
+        {/* パスワード入力欄　*/}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>パスワード</label>
+            <input
+              type="password"
+              className={`${inputBase} ${errors.userPassword ? 'border-red-500' : 'border-gray-400'}`}
+              {...register("userPassword", {
+                required: "パスワードは必須です",
+                minLength: { value: 8, message: "8文字以上で入力してください" },
+                maxLength: { value: 19, message: "20文字未満で入力してください" },
+                pattern: {
+                  value: /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[^\w\s]).+$/,
+                  message: "英字・数字・記号をすべて含めてください"
+                }
+              })}
+            />
+          </div>
+          <div className='h-4 ml-32'>
+            {errors.userPassword && <span className='text-red-500 text-xs'>{errors.userPassword.message}</span>}
+          </div>
+        </div>
+
+        {/* メールアドレス　*/}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>メールアドレス</label>
+            <input
+              type="email"
+              className={`${inputBase} ${errors.userEmail ? 'border-red-500' : 'border-gray-400'}`}
+              {...register("userEmail", {
+                required: "メールアドレスは必須です",
+                pattern: {
+                  value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                  message: "メールアドレスの形式が正しくありません"}
+              })}
+            />
+          </div>
+          <div className='h-4 ml-32'>
+            {errors.userEmail && <span className='text-red-500 text-xs'>{errors.userEmail.message}</span>}
+          </div>
+        </div>
+
+        {/* 月額設定額 */}
+        <div className='flex flex-col'>
+          <div className='flex items-center'>
+            <label className={labelClass}>月額予算</label>
+            <input
+              type="number"
+              min="0"
+              className={`${inputBase} ${errors.budget ? 'border-red-500' : 'border-gray-400'}`}
+              {...register("budget", {
+                valueAsNumber: true,
+                min: { value: 0, message: "0円以上の金額を入力して下さい" }
+              })}
+            />
+            <span className='ml-2 text-sm'>円</span>
+          </div>
+
+          <div className='h-6 ml-32 mt-1'>
+            {/* エラーがある時は赤メッセージ */}
+            {errors.budget && (
+              <span className='text-red-500 text-xs'>
+                {errors.budget.message}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className='ml-32 w-72 flex justify-center space-x-4 mt-8'>
+          <FormButton type="button" label="キャンセル" className={btnClass} onClick={handleGoToLogin} />
+          <FormButton type="submit" label="確定" className={btnClass} />
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default Signup;

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -120,7 +120,8 @@ const Signup = () => {
               min="0"
               className={`${inputBase} ${errors.budget ? 'border-red-500' : 'border-gray-400'}`}
               {...register("budget", {
-                valueAsNumber: true,
+                setValueAs: (value) => (value === "" ? 0 : Number(value)),
+                validate: (v) => Number.isFinite(v) || "有効な金額を入力して下さい",
                 min: { value: 0, message: "0円以上の金額を入力して下さい" }
               })}
             />

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,20 @@
+export type User = {
+  user_id: number;
+  user_name: string;
+  monthly_budget: number;
+};
+
+export type Category = {
+  category_id: number;
+  user_id: number | null;
+  category_name: string;
+};
+
+export type Detail = {
+  detail_id: number;
+  user_id: number;
+  category_id: number;
+  expense_date: string;
+  amount: number; 
+  description: string;
+};

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,20 +1,7 @@
+// ユーザー情報を型定義
 export type User = {
-  user_id: number;
-  user_name: string;
-  monthly_budget: number;
-};
-
-export type Category = {
-  category_id: number;
-  user_id: number | null;
-  category_name: string;
-};
-
-export type Detail = {
-  detail_id: number;
-  user_id: number;
-  category_id: number;
-  expense_date: string;
-  amount: number; 
-  description: string;
+  user_id: number;  // ユーザーを一意に識別するID（自動採番）
+  user_name: string; // ユーザー名
+  user_email: string; // メールアドレス
+  monthly_budget: number | null; // ユーザーが設定した１ヶ月あたりの予算
 };

--- a/frontend/src/types/expense.ts
+++ b/frontend/src/types/expense.ts
@@ -1,0 +1,16 @@
+// 支出分類（食費、日用品等）の型定義
+export type Category = {
+  category_id: number;  // カテゴリーを一意に識別するID（自動採番）
+  user_id: number | null;  // カテゴリーを作成したユーザーID,nullの場合デフォルト
+  category_name: string; // カテゴリ名称
+};
+
+// 支出明細の型定義
+export type Detail = {
+  detail_id: number;  // 明細を一意に識別するID（自動採番）
+  user_id: number;  // 支出を登録したユーザーID
+  category_id: number;  // 紐付くカテゴリID
+  expense_date: string;  // 支出日
+  amount: number;  // 支出金額
+  description: string | null;  // 補足説明
+};


### PR DESCRIPTION
# ルーティングの設定と各画面への遷移定義
 - App.tsxのルーティング設定と各画面定義
 
# ログイン画面の実装
 - ログイン画面の実装
 
# 認証機能（ログイン）のフロントエンド・バックエンド連携の実装
 - フロントエンド　/src/api/auth.ts
                                /src/types/auth.ts.   の実装
 - バックエンド      /src/routes/auth.ts 　
                                /src/index.ts　の実装

# ボタンコンポーネントの実装
- ログイン画面、新規登録画面上のボタンコンポーネント実装

# App.tsxの修正
- ログイン画面と新規登録画面のみ画面遷移に修正

# ログイン画面の修正と新規登録画面の実装
- ログイン画面（Login.tsx）のimport文の修正
- 新規登録画面（Signup.tsx）の初回プルリク

# BASE_URLを相対パスに修正
- frontend/src/api/auth.ts　BASE_URLを相対パスに修正

# backend/src/routes/auth.ts の下記の修正
- 月額設定APIのメソッド変更
- ユーザー名・パスワードの存在／型チェックを追加
- signupで例外時に500を返却
- loginでユーザー重複チェックを追加

# 不要空白の削除
- backend/src/index.ts allowMethods箇所の不要空白削除

# App.tsxの不要ロジック削除
- App.tsxの不要ロジック削除

# 新規登録画面（Signup.tsx）の修正
- ユーザー名の文字数チェックを削除
- メールアドレスの項目とバリデーションを追加

# 型定義にメールアドレスを追加
- 型定義（frontend/src/types/auth.ts）にメールアドレスの型定義を追加

# 型定義のファイル分割とコメント付与
- 型定義ファイルを役割（ユーザー認証関連と明細関連）に応じてファイル分割作成（auth.tsとexpense.ts）
- 定義項目に対しコメント付与（ユーザー名とメールアドレスは理解可能と判断しコメントなし）

# メールアドレス項目追加に伴う、データ送信ファイルの修正
- 画面項目：メールアドレス追加に伴い、メールアドレスを送信データとして追加（frontend/src/api/auth.ts）

# ログイン画面（Login.tsx）の修正
- メールアドレスの項目とバリデーションを追加

# バックエンド関数（auth.ts）の修正
- ユーザー情報検索・取得時のコメント修正
- 重複チェックの削除

# フロントエンド関数（auth.ts）の修正
- メールアドレス追加とバックエンド関数とのデータ整合性の見直しによる修正

# 新規登録画面の修正
- 月額設定額が空白で設定された場合、ゼロとしてみなすロジックの追加

# ログイン画面の修正
- メールアドレス、パスワードにより一意となるためユーザー名の入力項目を削除（AI指摘　PO指示）

# 型定義の再プルリク
- 型定義の最新版でのプルリク（auth.ts/expense.ts）