### PR TITLE
E2Eテスト（issue22）

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS details (
 -- users テーブル
 INSERT INTO users (user_name, user_password, user_email, monthly_budget) VALUES
   ('鈴木太郎', 'Pass1234', 'abcd1234@gmail.com', 100000);
+  ('E2Eテストユーザー', 'Test1234!', 'e2e@test.com', 12345);
 
 -- categories テーブル
 INSERT INTO categories (category_name, user_id) VALUES

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "playwright test"
   },
   "keywords": [],
   "author": "",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  use: {
+    // アプリケーションの URL を指定する
+    baseURL: "http://localhost:5173",
+    // テスト失敗時にスクリーンショットを保存する
+    screenshot: "only-on-failure",
+  },
+  // タイムアウト設定
+  timeout: 30000,
+});

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, Page } from "@playwright/test";
+
+// ログインヘルパー関数
+async function loginAs(page: Page, email: string, password: string) {
+  await page.goto("/login");
+  await page.fill('input[type="password"]', password);
+  await page.fill('input[type="email"]', email);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL("/dashboard");
+}
+
+test.beforeEach(async ({ page }) => {
+  await loginAs(page, "e2e@test.com", "Test1234!");
+});
+
+test("テストケース１：正常系 - ダッシュボードにユーザー名が表示される", async ({ page }) => {
+
+  await expect(page.getByText(/様/)).toBeVisible();
+});
+
+test("テストケース２：正常系 - 今月の予算・支出・残高が表示される", async ({ page }) => {
+
+  await expect(page.getByText("今月の予算")).toBeVisible();
+  await expect(page.getByText("今月の支出")).toBeVisible();
+  await expect(page.getByText("残高")).toBeVisible();
+  await expect(page.getByText("円").first()).toBeVisible();
+});
+
+test("テストケース３：正常系 - 予算を編集して保存できる", async ({ page }) => {
+
+  await page.getByRole("button", { name: "編集" }).click();
+
+  await expect(page.getByRole("button", { name: "保存" })).toBeVisible();
+  await page.locator('input[type="number"]').fill("12345");
+  await page.getByRole("button", { name: "保存" }).click();
+
+  await expect(page.getByRole("button", { name: "保存" })).not.toBeVisible();
+  await expect(page.getByText("12,345").first()).toBeVisible();
+});
+
+test("テストケース４：正常系 - 予算編集モーダルのキャンセルボタンでモーダルが閉じる", async ({ page }) => {
+
+  await page.getByRole("button", { name: "編集" }).click();
+
+  await expect(page.getByRole("button", { name: "保存" })).toBeVisible();
+  await page.getByRole("button", { name: "キャンセル" }).click();
+  await expect(page.getByRole("button", { name: "保存" })).not.toBeVisible();
+});
+
+test("テストケース５：ナビゲーション - 「支出を入力」ボタンをクリックすると支出入力画面に遷移する", async ({ page }) => {
+
+  await page.getByRole("button", { name: "支出を入力" }).click();
+  await expect(page).toHaveURL("/input");
+});

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -1,13 +1,5 @@
-import { test, expect, Page } from "@playwright/test";
-
-// ログインヘルパー関数
-async function loginAs(page: Page, email: string, password: string) {
-  await page.goto("/login");
-  await page.fill('input[type="password"]', password);
-  await page.fill('input[type="email"]', email);
-  await page.click('button[type="submit"]');
-  await expect(page).toHaveURL("/dashboard");
-}
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers";
 
 test.beforeEach(async ({ page }) => {
   await loginAs(page, "e2e@test.com", "Test1234!");

--- a/e2e/tests/expense-input.spec.ts
+++ b/e2e/tests/expense-input.spec.ts
@@ -32,7 +32,7 @@ test("テストケース２：バリデーション - 日付が未入力のと�
   await expect(page.getByText("日付を入力してください")).toBeVisible();
 });
 
-test("テストケース３：バリデーション - - カテゴリが未入力のとき、エラーが表示される", async ({ page }) => {
+test("テストケース３：バリデーション - カテゴリが未入力のとき、エラーが表示される", async ({ page }) => {
 
   await page.locator('input[type="date"]').fill("2026-04-01");
   await page.locator('input[type="number"]').fill("1500");

--- a/e2e/tests/expense-input.spec.ts
+++ b/e2e/tests/expense-input.spec.ts
@@ -1,22 +1,13 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers";
 
-// ログインヘルパー関数
-async function loginAs(page: Page, email: string, password: string) {
-  await page.goto("/login");
-  await page.fill('input[type="password"]', password);
-  await page.fill('input[type="email"]', email);
-  await page.click('button[type="submit"]');
-  await expect(page).toHaveURL("/dashboard");
-}
-
-  test.beforeEach(async ({ page }) => {
-    await loginAs(page, "e2e@test.com", "Test1234!");
+test.beforeEach(async ({ page }) => {
+  await loginAs(page, "e2e@test.com", "Test1234!");
+  await page.getByRole("button", { name: "支出を入力" }).click();
+  await expect(page).toHaveURL("/input");
 });
 
 test("テストケース１：正常系 - 支出を入力して登録できる", async ({ page }) => {
-  await page.getByRole("button", { name: "支出を入力" }).click();
-
-  await expect(page).toHaveURL("/input");
 
   await page.locator('input[type="date"]').fill("2026-04-01");
   await page.locator('input[type="text"]').nth(0).fill("食費");
@@ -31,9 +22,6 @@ test("テストケース１：正常系 - 支出を入力して登録できる",
 });
 
 test("テストケース２：バリデーション - 日付が未入力のとき、エラーが表示される", async ({ page }) => {
-  await page.getByRole("button", { name: "支出を入力" }).click();
-
-  await expect(page).toHaveURL("/input");
 
   await page.locator('input[type="text"]').nth(0).fill("食費");
   await page.locator('input[type="number"]').fill("1500");
@@ -45,9 +33,6 @@ test("テストケース２：バリデーション - 日付が未入力のと�
 });
 
 test("テストケース３：バリデーション - - カテゴリが未入力のとき、エラーが表示される", async ({ page }) => {
-  await page.getByRole("button", { name: "支出を入力" }).click();
-
-  await expect(page).toHaveURL("/input");
 
   await page.locator('input[type="date"]').fill("2026-04-01");
   await page.locator('input[type="number"]').fill("1500");
@@ -59,9 +44,6 @@ test("テストケース３：バリデーション - - カテゴリが未入力
 });
 
 test("テストケース４：バリデーション - 金額が 0 以下のとき、エラーが表示される", async ({ page }) => {
-  await page.getByRole("button", { name: "支出を入力" }).click();
-
-  await expect(page).toHaveURL("/input");
 
   await page.locator('input[type="date"]').fill("2026-04-01");
   await page.locator('input[type="text"]').nth(0).fill("食費");
@@ -74,9 +56,6 @@ test("テストケース４：バリデーション - 金額が 0 以下のと�
 });
 
 test("テストケース５：バリデーション - 費用詳細が 20 文字を超えるとき、エラーが表示される", async ({ page }) => {
-  await page.getByRole("button", { name: "支出を入力" }).click();
-
-  await expect(page).toHaveURL("/input");
 
   await page.locator('input[type="date"]').fill("2026-04-01");
   await page.locator('input[type="text"]').nth(0).fill("食費");

--- a/e2e/tests/expense-input.spec.ts
+++ b/e2e/tests/expense-input.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, Page } from "@playwright/test";
+
+// ログインヘルパー関数
+async function loginAs(page: Page, email: string, password: string) {
+  await page.goto("/login");
+  await page.fill('input[type="password"]', password);
+  await page.fill('input[type="email"]', email);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL("/dashboard");
+}
+
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, "e2e@test.com", "Test1234!");
+});
+
+test("テストケース１：正常系 - 支出を入力して登録できる", async ({ page }) => {
+  await page.getByRole("button", { name: "支出を入力" }).click();
+
+  await expect(page).toHaveURL("/input");
+
+  await page.locator('input[type="date"]').fill("2026-04-01");
+  await page.locator('input[type="text"]').nth(0).fill("食費");
+  await page.locator('input[type="number"]').fill("1500");
+  await page.locator('textarea').fill("ランチ代");
+
+  page.once("dialog", (dialog) => dialog.accept());
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page).toHaveURL("/dashboard");
+});
+
+test("テストケース２：バリデーション - 日付が未入力のとき、エラーが表示される", async ({ page }) => {
+  await page.getByRole("button", { name: "支出を入力" }).click();
+
+  await expect(page).toHaveURL("/input");
+
+  await page.locator('input[type="text"]').nth(0).fill("食費");
+  await page.locator('input[type="number"]').fill("1500");
+  await page.locator('textarea').fill("ランチ代");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("日付を入力してください")).toBeVisible();
+});
+
+test("テストケース３：バリデーション - - カテゴリが未入力のとき、エラーが表示される", async ({ page }) => {
+  await page.getByRole("button", { name: "支出を入力" }).click();
+
+  await expect(page).toHaveURL("/input");
+
+  await page.locator('input[type="date"]').fill("2026-04-01");
+  await page.locator('input[type="number"]').fill("1500");
+  await page.locator('textarea').fill("ランチ代");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("カテゴリを入力してください")).toBeVisible();
+});
+
+test("テストケース４：バリデーション - 金額が 0 以下のとき、エラーが表示される", async ({ page }) => {
+  await page.getByRole("button", { name: "支出を入力" }).click();
+
+  await expect(page).toHaveURL("/input");
+
+  await page.locator('input[type="date"]').fill("2026-04-01");
+  await page.locator('input[type="text"]').nth(0).fill("食費");
+  await page.locator('input[type="number"]').fill("0");
+  await page.locator('textarea').fill("ランチ代");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("１円以上の金額を入力して下さい")).toBeVisible();
+});
+
+test("テストケース５：バリデーション - 費用詳細が 20 文字を超えるとき、エラーが表示される", async ({ page }) => {
+  await page.getByRole("button", { name: "支出を入力" }).click();
+
+  await expect(page).toHaveURL("/input");
+
+  await page.locator('input[type="date"]').fill("2026-04-01");
+  await page.locator('input[type="text"]').nth(0).fill("食費");
+  await page.locator('input[type="number"]').fill("1500");
+  await page.locator('textarea').fill("東京都中央区のマクドナルドの店内でセットを購入");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("20文字以内で入力してください")).toBeVisible();
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,0 +1,10 @@
+import { expect, Page } from "@playwright/test";
+
+// ログインヘルパー関数
+export async function loginAs(page: Page, email: string, password: string) {
+  await page.goto("/login");
+  await page.fill('input[type="password"]', password);
+  await page.fill('input[type="email"]', email);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL("/dashboard");
+}

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("テストケース 1：正常系 - ログイン成功してダッシュボードへ遷移する", async ({ page }) => {
+test("テストケース１：正常系 - ログイン成功してダッシュボードへ遷移する", async ({ page }) => {
   await page.goto("/login");
 
   await page.fill('input[type="password"]', "Test1234!");
@@ -12,7 +12,7 @@ test("テストケース 1：正常系 - ログイン成功してダッシュボ
   await expect(page.getByText("ダッシュボード")).toBeVisible();
 });
 
-test("テストケース ２：異常系 - パスワードが間違っているときエラーメッセージが表示される", async ({ page }) => {
+test("テストケース２：異常系 - パスワードが間違っているときエラーメッセージが表示される", async ({ page }) => {
   await page.goto("/login");
 
   await page.fill('input[type="password"]', "Test1234#");
@@ -24,7 +24,7 @@ test("テストケース ２：異常系 - パスワードが間違っている�
   await expect(page).toHaveURL("/login");
 });
 
-test("テストケース ３：異常系 - メールアドレスが未入力のとき、バリデーションエラーが表示される", async ({ page }) => {
+test("テストケース３：異常系 - メールアドレスが未入力のとき、バリデーションエラーが表示される", async ({ page }) => {
   await page.goto("/login");
 
   await page.fill('input[type="password"]', "Test1234!");
@@ -35,7 +35,7 @@ test("テストケース ３：異常系 - メールアドレスが未入力の�
   await expect(page.getByText("メールアドレスは必須です")).toBeVisible();
 });
 
-test("テストケース ４：正常系 - ログアウトするとログイン画面に戻る", async ({ page }) => {
+test("テストケース４：正常系 - ログアウトするとログイン画面に戻る", async ({ page }) => {
   await page.goto("/login");
 
   await page.fill('input[type="password"]', "Test1234!");
@@ -50,10 +50,7 @@ test("テストケース ４：正常系 - ログアウトするとログイン�
   await expect(page).toHaveURL("/login");
 });
 
-test("テストケース ５：正常系 - ログインしていないとき、/dashboard にアクセスするとログイン画面にリダイレクトされる", async ({ page }) => {
-  await page.goto("/login");
-  await page.evaluate(() => localStorage.clear());
-
+test("テストケース５：正常系 - ログインしていないとき、/dashboard にアクセスするとログイン画面にリダイレクトされる", async ({ page }) => {
   await page.goto("/dashboard");
 
   await expect(page).toHaveURL("/login");

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+test("テストケース 1：正常系 - ログイン成功してダッシュボードへ遷移する", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.fill('input[type="password"]', "Test1234!");
+  await page.fill('input[type="email"]', "e2e@test.com");
+
+  await page.getByRole("button", { name: "ログイン" }).click();
+
+  await expect(page).toHaveURL("/dashboard");
+  await expect(page.getByText("ダッシュボード")).toBeVisible();
+});
+
+test("テストケース ２：異常系 - パスワードが間違っているときエラーメッセージが表示される", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.fill('input[type="password"]', "Test1234#");
+  await page.fill('input[type="email"]', "e2e@test.com");
+
+  await page.getByRole("button", { name: "ログイン" }).click();
+
+  await expect(page.getByText("メールアドレスまたはパスワードが違います")).toBeVisible();
+  await expect(page).toHaveURL("/login");
+});
+
+test("テストケース ３：異常系 - メールアドレスが未入力のとき、バリデーションエラーが表示される", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.fill('input[type="password"]', "Test1234!");
+  await page.fill('input[type="email"]', "");
+
+  await page.getByRole("button", { name: "ログイン" }).click();
+
+  await expect(page.getByText("メールアドレスは必須です")).toBeVisible();
+});
+
+test("テストケース ４：正常系 - ログアウトするとログイン画面に戻る", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.fill('input[type="password"]', "Test1234!");
+  await page.fill('input[type="email"]', "e2e@test.com");
+
+  await page.getByRole("button", { name: "ログイン" }).click();
+
+  await expect(page).toHaveURL("/dashboard");
+
+  await page.getByRole("button", { name: "ログアウト" }).click();
+
+  await expect(page).toHaveURL("/login");
+});
+
+test("テストケース ５：正常系 - ログインしていないとき、/dashboard にアクセスするとログイン画面にリダイレクトされる", async ({ page }) => {
+  await page.goto("/login");
+  await page.evaluate(() => localStorage.clear());
+
+  await page.goto("/dashboard");
+
+  await expect(page).toHaveURL("/login");
+});

--- a/e2e/tests/signup.spec.ts
+++ b/e2e/tests/signup.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "@playwright/test";
+
+test("テストケース１：正常系 - 新規登録が成功してログイン画面に遷移する", async ({ page }) => {
+  await page.goto("/signup");
+
+  const uniqueEmail = `test_${Date.now()}@example.com`;
+
+  await page.fill('input[name="userName"]', "テストユーザー");
+  await page.fill('input[name="userPassword"]', "Test1234!");
+  await page.fill('input[name="userEmail"]', uniqueEmail);
+  await page.fill('input[name="budget"]', "50000");
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page).toHaveURL("/login");
+});
+
+test("テストケース２：バリデーション - ユーザー名が未入力のとき、エラーが表示される", async ({ page }) => {
+
+  await page.goto("/signup");
+
+  const uniqueEmail = `test_${Date.now()}@example.com`;
+
+  await page.fill('input[name="userPassword"]', "Test1234!");
+  await page.fill('input[name="userEmail"]', uniqueEmail);
+  await page.fill('input[name="budget"]', "50000");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("ユーザー名は必須です")).toBeVisible();
+});
+
+test("テストケース３：バリデーション - パスワードが8文字未満のとき、エラーが表示される", async ({ page }) => {
+
+  await page.goto("/signup");
+
+  const uniqueEmail = `test_${Date.now()}@example.com`;
+
+  await page.fill('input[name="userName"]', "テストユーザー");
+  await page.fill('input[name="userPassword"]', "Ab@1234");
+  await page.fill('input[name="userEmail"]', uniqueEmail);
+  await page.fill('input[name="budget"]', "50000");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("8文字以上で入力してください")).toBeVisible();
+});
+
+test("テストケース４：バリデーション - パスワードに英字・数字・記号が含まれていないとき、エラーが表示される", async ({ page }) => {
+
+  await page.goto("/signup");
+
+  const uniqueEmail = `test_${Date.now()}@example.com`;
+
+  await page.fill('input[name="userName"]', "テストユーザー");
+  await page.fill('input[name="userPassword"]', "abcdefgh");
+  await page.fill('input[name="userEmail"]', uniqueEmail);
+  await page.fill('input[name="budget"]', "50000");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("英字・数字・記号をすべて含めてください")).toBeVisible();
+});
+
+test("テストケース５：バリデーション - メールアドレスの形式が不正なとき、エラーが表示される", async ({ page }) => {
+
+  await page.goto("/signup");
+
+  await page.fill('input[name="userName"]', "テストユーザー");
+  await page.fill('input[name="userPassword"]', "Test1234!");
+  await page.fill('input[name="userEmail"]', "notanemail");
+  await page.fill('input[name="budget"]', "50000");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("メールアドレスの形式が正しくありません")).toBeVisible();
+});
+
+test("テストケース６：バリデーション - 月額予算に負の値を入力したとき、エラーが表示される", async ({ page }) => {
+
+  await page.goto("/signup");
+
+  const uniqueEmail = `test_${Date.now()}@example.com`;
+
+  await page.fill('input[name="userName"]', "テストユーザー");
+  await page.fill('input[name="userPassword"]', "Test1234!");
+  await page.fill('input[name="userEmail"]', uniqueEmail);
+  await page.fill('input[name="budget"]', "-100");
+
+  await page.getByRole("button", { name: "確定" }).click();
+
+  await expect(page.getByText("0円以上の金額を入力して下さい")).toBeVisible();
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,8 +10,7 @@ export default defineConfig({
     proxy: {
       // /api/* へのリクエストをバックエンドサーバーへ転送する
       "/api": {
-        // target: "http://backend:3000",
-        target: "http://localhost:3000",
+        target: "http://backend:3000",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
# 環境設定ファイル
# ログイン・ログアウトテスト
- login.spec.ts
# 新規登録テスト
- signup.spec.ts
# ダッシュボードテスト
- dashboard.spec.ts
# 支出入力テスト
- expense-input.spec.ts

# レビュー指摘時修正
- helpers.ts の新規作成（共通処理loginAsの関数化）
- dashboard.spec.ts
 1. loginAs処理の削除
- login.spec.ts
 1. 不要ログイン処理の削除
- expense-input.spec.ts
 1. loginAs処理の削除
 2. 不要スペースの削除
 3. 全ケース共通処理をtest.beforeEach処理に内包

他：各テストケースの「テストケース１」の数字を全角化

# AIレビュー指摘事項修正
- expense-input.spec.ts
 1.不要ハイフンの削除
- package.json
 1.npm testでE2Eテスト実行可能とする
-  init.sql
 1.E2Eテスト用のユーザー情報追加